### PR TITLE
Identifier enum

### DIFF
--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity.xcodeproj/project.pbxproj
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 			isa = PBXGroup;
 			children = (
 				06B4404B216BA5F90062BEDF /* SFWCardsAgainstHumanity */,
-				06B44062216BD35D0062BEDF /* Helpers */,
 				06B4404A216BA5F90062BEDF /* Products */,
 			);
 			sourceTree = "<group>";
@@ -62,6 +61,7 @@
 				06B44053216BA5FA0062BEDF /* Assets.xcassets */,
 				06B44055216BA5FA0062BEDF /* LaunchScreen.storyboard */,
 				06B44058216BA5FA0062BEDF /* Info.plist */,
+				06B44062216BD35D0062BEDF /* Helpers */,
 			);
 			path = SFWCardsAgainstHumanity;
 			sourceTree = "<group>";

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity.xcodeproj/project.pbxproj
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		06B44054216BA5FA0062BEDF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 06B44053216BA5FA0062BEDF /* Assets.xcassets */; };
 		06B44057216BA5FA0062BEDF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 06B44055216BA5FA0062BEDF /* LaunchScreen.storyboard */; };
 		06B44061216BCAF00062BEDF /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B44060216BCAF00062BEDF /* HomeViewController.swift */; };
+		06B44064216BD4230062BEDF /* IdentityEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B44063216BD4230062BEDF /* IdentityEnum.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,6 +23,7 @@
 		06B44056216BA5FA0062BEDF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		06B44058216BA5FA0062BEDF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		06B44060216BCAF00062BEDF /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		06B44063216BD4230062BEDF /* IdentityEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityEnum.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,6 +86,7 @@
 		06B44062216BD35D0062BEDF /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				06B44063216BD4230062BEDF /* IdentityEnum.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -160,6 +163,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				06B4404D216BA5F90062BEDF /* AppDelegate.swift in Sources */,
+				06B44064216BD4230062BEDF /* IdentityEnum.swift in Sources */,
 				06B44061216BCAF00062BEDF /* HomeViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity.xcodeproj/project.pbxproj
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 			isa = PBXGroup;
 			children = (
 				06B4404B216BA5F90062BEDF /* SFWCardsAgainstHumanity */,
+				06B44062216BD35D0062BEDF /* Helpers */,
 				06B4404A216BA5F90062BEDF /* Products */,
 			);
 			sourceTree = "<group>";
@@ -78,6 +79,13 @@
 				06B44060216BCAF00062BEDF /* HomeViewController.swift */,
 			);
 			path = Controllers;
+			sourceTree = "<group>";
+		};
+		06B44062216BD35D0062BEDF /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Helpers/IdentityEnum.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Helpers/IdentityEnum.swift
@@ -1,0 +1,33 @@
+//
+//  IdentityEnum.swift
+//  SFWCardsAgainstHumanity
+//
+//  Created by Britney Smith on 10/8/18.
+//  Copyright © 2018 Britney Smith. All rights reserved.
+//
+
+import Foundation
+
+enum Identity: String {
+    case homeVC
+    
+    case segueIDToChange
+    
+    var storyboardID: String {
+        switch self {
+        case .homeVC:
+            return "HomeViewController"
+        default:
+            return ""
+        }
+    }
+    
+    var segueID: String {
+        switch self {
+        case .segueIDToChange:
+            return ""
+        default:
+            return ""
+        }
+    }
+}


### PR DESCRIPTION
## What you did :question:
- Added enum to handle identities (storyboard, segue, etc)

## How you did it :white_check_mark:
- Set up enum Identity in 'Helpers' folder
- Used switch in computed property to specify identity type (ex: one for 'storyboardID', another for 'segueID'
- Used computed property to organize cases


## How to test it :microscope:
- Add following to viewDidLoad of the HomeViewController and run app: 
`print("\(Identity.homeVC.storyboardID)")`
- The string 'HomeViewController' should show in the terminal


## Screenshots (if applicable) :camera:
<img width="1412" alt="screen shot 2018-10-08 at 2 24 29 pm" src="https://user-images.githubusercontent.com/8409475/46626630-e90cb800-cb05-11e8-9ded-011b3c194962.png">
<img width="1423" alt="screen shot 2018-10-08 at 2 23 32 pm" src="https://user-images.githubusercontent.com/8409475/46626643-ef029900-cb05-11e8-85db-2cee240f1e1e.png">
