### PR TITLE
Html symbol decoding

### DIFF
--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
@@ -59,9 +59,15 @@ class PlayViewController: UIViewController {
         guard let whiteCardPhrases = whiteCardsJSON?.phrases else { return }
         let shuffledWhiteCards = whiteCardPhrases.shuffled()
         
-        whiteCard1 = decodeHTMLString(for: shuffledWhiteCards[0]!).string
-        whiteCard2 = decodeHTMLString(for: shuffledWhiteCards[1]!).string
-        whiteCard3 = decodeHTMLString(for: shuffledWhiteCards[2]!).string
+        guard
+            let encodedStringOne = shuffledWhiteCards[0],
+            let encodedStringTwo = shuffledWhiteCards[1],
+            let encodedStringThree = shuffledWhiteCards[2]
+        else { return }
+        
+        whiteCard1 = decodeHTMLString(for: encodedStringOne).string
+        whiteCard2 = decodeHTMLString(for: encodedStringTwo).string
+        whiteCard3 = decodeHTMLString(for: encodedStringThree).string
         
         whiteCardPhrase1Button.setTitle(whiteCard1, for: .normal)
         whiteCardPhrase2Button.setTitle(whiteCard2, for: .normal)
@@ -119,7 +125,8 @@ class PlayViewController: UIViewController {
     }
     
     func setBlackCardLabel(for blackCard: BlackCard) {
-        blackCardLabel.text = decodeHTMLString(for: blackCard.text!).string
+        guard let encodedString = blackCard.text else { return }
+        blackCardLabel.text = decodeHTMLString(for: encodedString).string
         setPickNumberLabel(blackCard: blackCard)
     }
     

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
@@ -42,13 +42,26 @@ class PlayViewController: UIViewController {
     
     // MARK: Methods
     
+    func decodeHTMLString(for htmlEncodedString: String) -> NSAttributedString {
+        guard let data = htmlEncodedString.data(using: .utf8) else { return NSAttributedString() }
+        
+        do {
+            return try NSAttributedString(data: data, options: [
+                .documentType: NSAttributedString.DocumentType.html,
+                .characterEncoding: String.Encoding.utf8.rawValue
+                ], documentAttributes: nil)
+        } catch {
+            return NSAttributedString()
+        }
+    }
+    
     func setWhiteCardButtonTitles() {
         guard let whiteCardPhrases = whiteCardsJSON?.phrases else { return }
         let shuffledWhiteCards = whiteCardPhrases.shuffled()
         
-        whiteCard1 = shuffledWhiteCards[0]
-        whiteCard2 = shuffledWhiteCards[1]
-        whiteCard3 = shuffledWhiteCards[2]
+        whiteCard1 = decodeHTMLString(for: shuffledWhiteCards[0]!).string
+        whiteCard2 = decodeHTMLString(for: shuffledWhiteCards[1]!).string
+        whiteCard3 = decodeHTMLString(for: shuffledWhiteCards[2]!).string
         
         whiteCardPhrase1Button.setTitle(whiteCard1, for: .normal)
         whiteCardPhrase2Button.setTitle(whiteCard2, for: .normal)
@@ -106,7 +119,7 @@ class PlayViewController: UIViewController {
     }
     
     func setBlackCardLabel(for blackCard: BlackCard) {
-        blackCardLabel.text = blackCard.text
+        blackCardLabel.text = decodeHTMLString(for: blackCard.text!).string
         setPickNumberLabel(blackCard: blackCard)
     }
     


### PR DESCRIPTION
## What you did :question:
- Added functionality for decoding HTML symbols in strings received from JSON


## How you did it :white_check_mark:
- Added method to decode HTML encoded string and return NSAttributedString
- Converted the returned NSAttributedString to String
- Assigned that String to Black Card label text and white card button titles
#### Sources: 
- https://stackoverflow.com/questions/25607247/how-do-i-decode-html-entities-in-swift
- https://stackoverflow.com/questions/44390520/cannot-convert-value-of-type-nsattributedstring-documentattributekey-to-documen (updated for Swift 4)


## How to test it :microscope:
- Replace values with the following test code in PlayViewController.swift where applicable: 

```
func setWhiteCardButtonTitles() {
       //...
        whiteCard1 = decodeHTMLString(for: "&trade;").string
        whiteCard2 = decodeHTMLString(for: "&reg;").string
        whiteCard3 = decodeHTMLString(for: "&trade;").string
        
       //...
    }
//...
func setBlackCardLabel(for blackCard: BlackCard) {
        //...
        blackCardLabel.text = decodeHTMLString(for: "&reg;").string
       //...
    }
```

- Run the app!
- Tap 'Play!'
- HTML symbols should render as expected in Black Cards and white card options
ex: `&trade;` should be &trade; & `&reg;` should be &reg;


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-10-16 at 15 13 16](https://user-images.githubusercontent.com/8409475/47041868-e76f6f80-d157-11e8-96bf-d0cea9f118e8.png)
