### PR TITLE
New round button

### DIFF
--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
@@ -41,11 +41,29 @@ class PlayViewController: UIViewController {
     
     // MARK: Methods
     
-    /// TODO: method to reset white card button options and See Selection button
+    
+    func resetWhiteCardButtons() {
+        let buttonArray = [whiteCardPhrase1Button, whiteCardPhrase2Button, whiteCardPhrase3Button]
+        
+        for button in buttonArray {
+            guard let button = button else { return }
+            button.isSelected = false
+            button.isHighlighted = false
+            
+            if !button.isEnabled {
+                toggleEnabledButtonState(for: button)
+            }
+        }
+    }
+    
+    func resetSeeSelectionButton() {
+        
+    }
     
     func newRound() {
         seeSelectionButton.isEnabled = false
         toggleDisabledButtonStyling(for: seeSelectionButton)
+        resetWhiteCardButtons()
         getCardData()
     }
     

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
@@ -57,13 +57,13 @@ class PlayViewController: UIViewController {
     }
     
     func resetSeeSelectionButton() {
-        
+        seeSelectionButton.isEnabled = false
+        toggleDisabledButtonStyling(for: seeSelectionButton)
     }
     
     func newRound() {
-        seeSelectionButton.isEnabled = false
-        toggleDisabledButtonStyling(for: seeSelectionButton)
         resetWhiteCardButtons()
+        resetSeeSelectionButton()
         getCardData()
     }
     

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
@@ -36,11 +36,18 @@ class PlayViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        toggleEnabledButtonState(for: seeSelectionButton)
-        getCardData()
+        newRound()
     }
     
     // MARK: Methods
+    
+    /// TODO: method to reset white card button options and See Selection button
+    
+    func newRound() {
+        seeSelectionButton.isEnabled = false
+        toggleDisabledButtonStyling(for: seeSelectionButton)
+        getCardData()
+    }
     
     func decodeHTMLString(for htmlEncodedString: String) -> NSAttributedString {
         guard let data = htmlEncodedString.data(using: .utf8) else { return NSAttributedString() }
@@ -176,6 +183,7 @@ class PlayViewController: UIViewController {
     }
     
     @IBAction func userTappedNewRoundButton(_ sender: UIButton) {
+        newRound()
     }
     
     

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
@@ -175,6 +175,10 @@ class PlayViewController: UIViewController {
         print(selection)
     }
     
+    @IBAction func userTappedNewRoundButton(_ sender: UIButton) {
+    }
+    
+    
 }
 
 

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
@@ -119,6 +119,17 @@
                                     <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RTp-in-HkP">
+                                <rect key="frame" x="16" y="617" width="117" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" red="1" green="0.050894779430000002" blue="0.47870025989999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <state key="normal" title="New Round">
+                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="userTappedNewRoundButton:" destination="Ijd-Er-kX9" eventType="touchUpInside" id="tcS-bg-BVh"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <viewLayoutGuide key="safeArea" id="JDT-Kn-ml7"/>

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/BorderedButton.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/BorderedButton.swift
@@ -23,6 +23,7 @@ class BorderedButton: UIButton {
     override var isSelected: Bool {
         didSet {
             let blackColor = UIColor.black.cgColor
+            let baseColor = UIColor.white
             let highlightedColor = UIColor(red:1.00, green:0.05, blue:0.48, alpha:1.0)
             /// To get rid of the tint background upon selection
             self.tintColor = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.0)
@@ -30,8 +31,12 @@ class BorderedButton: UIButton {
             if isSelected {
                 layer.borderColor = blackColor
                 self.backgroundColor = highlightedColor
-                self.setTitleColor(UIColor.white, for: .normal)
+                self.setTitleColor(.white, for: .normal)
                 self.isEnabled = false
+            } else {
+                layer.borderColor = blackColor
+                self.backgroundColor = baseColor
+                self.setTitleColor(.black, for: .normal)
             }
         }
     }


### PR DESCRIPTION
## What you did :question:
- Added a 'New Round' button that reset the Black Card and white card options in the Play screen

## How you did it :white_check_mark:
- Added 'New Round' button in Storyboard
- Connected button to an IBAction method that called newRound() upon button tap
- Added methods to newRound() that reset the white card options and 'See Selection' button 


## How to test it :microscope:
- Run the app
- Tap 'Play!'
- Tapping the 'New Round' button should reload the Black Card and the white card options
- If a white card option is chosen and 'New Round' is tapped, card options should also be reset


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-10-17 at 10 07 52](https://user-images.githubusercontent.com/8409475/47092888-fd337200-d1f5-11e8-9b4f-38449abffcfc.png)
![simulator screen shot - iphone xr - 2018-10-17 at 10 07 59](https://user-images.githubusercontent.com/8409475/47092909-06244380-d1f6-11e8-8dcd-7ef6dfdab0c6.png)
![simulator screen shot - iphone xr - 2018-10-17 at 10 08 03](https://user-images.githubusercontent.com/8409475/47092927-0de3e800-d1f6-11e8-853c-eef9adaa0193.png)
