### PR TITLE
Added 'X' button to dismiss modal popup

### DIFF
--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/SelectionViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/SelectionViewController.swift
@@ -69,5 +69,11 @@ class SelectionViewController: UIViewController {
         populateWhiteCardLabels(linkedTo: blackCard)
     }
 
+    // MARK: Actions
+    
+    @IBAction func userTappedDismissButton(_ sender: BorderedButton) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
 
 }

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
@@ -192,6 +192,16 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iGf-DS-oci" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
+                                        <rect key="frame" x="202" y="0.0" width="30" height="30"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <state key="normal" title="X">
+                                            <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="userTappedDismissButton:" destination="syK-vQ-tIn" eventType="touchUpInside" id="aef-ng-2oz"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>


### PR DESCRIPTION
## What you did :question:
- Added 'X' button to dismiss modal popup

## How you did it :white_check_mark:
- Added 'X' button of type BorderedButton to the Selection View
- Connected button to IBAction method that dismissed the current Selection View Controller


## How to test it :microscope:
- Run the app
- Tap 'Play!'
- Choose any selection
- Tap 'See Selection'
- Tap 'X' on the modal popup, and it should disappear


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-10-17 at 17 32 03](https://user-images.githubusercontent.com/8409475/47117678-0989f000-d233-11e8-8b3c-029d776afe3f.png)
![simulator screen shot - iphone xr - 2018-10-17 at 17 32 08](https://user-images.githubusercontent.com/8409475/47117683-0e4ea400-d233-11e8-9787-e50625c3a26b.png)
![simulator screen shot - iphone xr - 2018-10-17 at 17 32 13](https://user-images.githubusercontent.com/8409475/47117687-13abee80-d233-11e8-8431-f9c669d39ace.png)
