### PR TITLE
Popup styling

### DIFF
--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/SelectionViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/SelectionViewController.swift
@@ -29,7 +29,7 @@ class SelectionViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        modalSelectionView.layer.cornerRadius = 10
         print("🃏In Selection View: \(currentSelection)")
         populateAllLabels()
         resetFavoriteButton()

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
@@ -154,7 +154,7 @@
         <!--Selection View Controller-->
         <scene sceneID="lPe-1o-QO0">
             <objects>
-                <viewController id="syK-vQ-tIn" customClass="SelectionViewController" customModule="SFWCardsAgainstHumanity" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController modalTransitionStyle="crossDissolve" modalPresentationStyle="overCurrentContext" id="syK-vQ-tIn" customClass="SelectionViewController" customModule="SFWCardsAgainstHumanity" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="pLr-6K-FPd">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -192,6 +192,15 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GM0-5e-Xfh">
+                                        <rect key="frame" x="171" y="445" width="61" height="51"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="tintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                        <state key="normal" title="heart"/>
+                                        <connections>
+                                            <action selector="userTappedFavoriteButton:" destination="syK-vQ-tIn" eventType="touchUpInside" id="YKy-dl-McI"/>
+                                        </connections>
+                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iGf-DS-oci" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
                                         <rect key="frame" x="202" y="0.0" width="30" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -202,20 +211,11 @@
                                             <action selector="userTappedDismissButton:" destination="syK-vQ-tIn" eventType="touchUpInside" id="aef-ng-2oz"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GM0-5e-Xfh">
-                                        <rect key="frame" x="171" y="445" width="61" height="51"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="tintColor" cocoaTouchSystemColor="darkTextColor"/>
-                                        <state key="normal" title="heart"/>
-                                        <connections>
-                                            <action selector="userTappedFavoriteButton:" destination="syK-vQ-tIn" eventType="touchUpInside" id="YKy-dl-McI"/>
-                                        </connections>
-                                    </button>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.50139363606770837" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <viewLayoutGuide key="safeArea" id="Qj6-GQ-K9p"/>
                     </view>
                     <connections>

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
@@ -160,55 +160,55 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="V60-zr-QWA">
-                                <rect key="frame" x="67" y="99" width="240" height="504"/>
+                                <rect key="frame" x="16" y="66" width="343" height="559"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="blackCard phrase" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aef-Mj-Nnd">
-                                        <rect key="frame" x="-4" y="40" width="248" height="131"/>
+                                        <rect key="frame" x="47" y="51" width="248" height="131"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="whiteCardLabelOne" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GV9-tE-cte" customClass="BorderedLabel" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                        <rect key="frame" x="8" y="190" width="224" height="54"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="whiteCardLabelTwo" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dr0-bN-uSu" customClass="BorderedLabel" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                        <rect key="frame" x="8" y="271" width="224" height="54"/>
+                                        <rect key="frame" x="59" y="326" width="224" height="54"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="whiteCardLabelThree" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fvk-gr-wnn" customClass="BorderedLabel" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                        <rect key="frame" x="8" y="347" width="224" height="54"/>
+                                        <rect key="frame" x="59" y="442" width="224" height="54"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GM0-5e-Xfh">
-                                        <rect key="frame" x="171" y="445" width="61" height="51"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="tintColor" cocoaTouchSystemColor="darkTextColor"/>
-                                        <state key="normal" title="heart"/>
-                                        <connections>
-                                            <action selector="userTappedFavoriteButton:" destination="syK-vQ-tIn" eventType="touchUpInside" id="YKy-dl-McI"/>
-                                        </connections>
-                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iGf-DS-oci" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                        <rect key="frame" x="202" y="0.0" width="30" height="30"/>
+                                        <rect key="frame" x="313" y="0.0" width="30" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="X">
                                             <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </state>
                                         <connections>
                                             <action selector="userTappedDismissButton:" destination="syK-vQ-tIn" eventType="touchUpInside" id="aef-ng-2oz"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="whiteCardLabelOne" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GV9-tE-cte" customClass="BorderedLabel" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
+                                        <rect key="frame" x="59" y="223" width="224" height="54"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GM0-5e-Xfh">
+                                        <rect key="frame" x="282" y="508" width="61" height="51"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="tintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                        <state key="normal" title="heart"/>
+                                        <connections>
+                                            <action selector="userTappedFavoriteButton:" destination="syK-vQ-tIn" eventType="touchUpInside" id="YKy-dl-McI"/>
                                         </connections>
                                     </button>
                                 </subviews>


### PR DESCRIPTION
## What you did :question:
- Styled the popup modal view

## How you did it :white_check_mark:
- Added black color with 50% opacity to the popup view controller
- Added rounded corners to the popup view
- Resized the popup view
- Moved labels and buttons to match the new popup view resizing

#### Sources:
- https://www.youtube.com/watch?v=S5i8n_bqblE

## How to test it :microscope:
- Run the app
- Tap 'Play!'
- Choose any selection
- Tap 'See Selection'
- Note that the popup has a black opacity set and cross dissolves into view


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-10-18 at 15 25 36](https://user-images.githubusercontent.com/8409475/47179147-474a4f80-d2eb-11e8-937b-4d04e4807fc4.png)
