### PR TITLE
Favorites detail segue

### DIFF
--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/FavoritesViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/FavoritesViewController.swift
@@ -43,7 +43,16 @@ extension FavoritesViewController: UICollectionViewDelegate, UICollectionViewDat
         cell.displayBlackCardLabel(blackCardText: decodedBlackCardText)
         return cell
     }
+}
+// MARK: Segue
+extension FavoritesViewController {
     
-    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        switch segue.identifier {
+        case Identity.favoritesToSelectionSegue.segueID:
+            guard let selectionViewController = segue.destination as? SelectionViewController else { return }
+            
+        }
+    }
 }
 

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/FavoritesViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/FavoritesViewController.swift
@@ -51,7 +51,14 @@ extension FavoritesViewController {
         switch segue.identifier {
         case Identity.favoritesToSelectionSegue.segueID:
             guard let selectionViewController = segue.destination as? SelectionViewController else { return }
-            
+            let cell = sender as! FavoritesCollectionViewCell
+            guard let indexPath = favoritesCollectionView.indexPath(for: cell) else { return }
+            let currentFavoriteSelection = favorites.favoritesList[(indexPath.row)]
+            selectionViewController.currentSelection.blackCard = currentFavoriteSelection.blackCard
+            selectionViewController.currentSelection.whiteCardPhrases = currentFavoriteSelection.whiteCardPhrases
+            selectionViewController.isFavorited = currentFavoriteSelection.isFavorited
+        default:
+            return
         }
     }
 }

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/SelectionViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/SelectionViewController.swift
@@ -34,7 +34,7 @@ class SelectionViewController: UIViewController {
         modalSelectionView.layer.cornerRadius = 10
         print("🃏In Selection View: \(currentSelection)")
         populateAllLabels()
-        resetFavoriteButton()
+        drawEmptyFavoriteButton()
     }
     
     // MARK: Methods
@@ -76,20 +76,26 @@ class SelectionViewController: UIViewController {
         populateWhiteCardLabels(linkedTo: blackCard)
     }
     
-    func resetFavoriteButton() {
-        isFavorited = false
+    func fillFavoriteButton() {
+        favoriteButton.setImage(favoriteFilledImage, for: .normal)
+        favoriteButton.imageView?.contentMode = .scaleAspectFit
+    }
+    
+    func drawEmptyFavoriteButton() {
         favoriteButton.setImage(favoriteImage, for: .normal)
         favoriteButton.imageView?.contentMode = .scaleAspectFit
+        if isFavorited {
+            fillFavoriteButton()
+        }
     }
     
     func toggleFavoriteButton() {
         
         if !isFavorited {
             isFavorited = true
-            favoriteButton.setImage(favoriteFilledImage, for: .normal)
-            favoriteButton.imageView?.contentMode = .scaleAspectFit
+            fillFavoriteButton()
         } else {
-            resetFavoriteButton()
+            drawEmptyFavoriteButton()
         }
     }
     

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Helpers/IdentityEnum.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Helpers/IdentityEnum.swift
@@ -16,6 +16,7 @@ enum Identity: String {
     case homeToPlaySegue
     case playToSelectionSegue
     case homeToFavoritesSegue
+    case favoritesToSelectionSegue
     
     case favoritesCell
     
@@ -40,6 +41,8 @@ enum Identity: String {
             return "playToSelection"
         case .homeToFavoritesSegue:
             return "homeToFavorites"
+        case .favoritesToSelectionSegue:
+            return "favoritesToSelection"
         default:
             return ""
         }

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
@@ -98,6 +98,7 @@
                                         </view>
                                         <connections>
                                             <outlet property="blackCardLabel" destination="0Vc-eJ-zsb" id="wDK-U6-uxk"/>
+                                            <segue destination="syK-vQ-tIn" kind="presentation" identifier="favoritesToSelection" id="Uax-ch-NMh"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
@@ -316,4 +317,7 @@
             <point key="canvasLocation" x="1920.8" y="29.23538230884558"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="Uax-ch-NMh"/>
+    </inferredMetricsTieBreakers>
 </document>


### PR DESCRIPTION
## What you did :question:
- Added functionality for viewing the details of a selected favorite in a modal popup 

## How you did it :white_check_mark:
- Added segue from favoritesCollectionView cell to Selection View modal popup
- Passed favorite selection card data and isFavorited state from Favorites CollectionView to Selection View vis segue
- Included SelectionViewController refactor or handling favorite button to retain isFavorited state visually


## How to test it :microscope:
- Run the app
- Tap 'Play!'
- Choose any selection
- Tap 'See Selection'
- Tap heart icon to make the selection a favorite
- Tap 'X' to exit Selection View
- Tap 'Back' to return to Home View
- Tap 'Faves'
- Tap the black card cell in the Favorites View
- A modal popup showing the black card, the selected white card phrases, and a filled heart icon should be displayed


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-10-23 at 09 43 07](https://user-images.githubusercontent.com/8409475/47365469-a0c6cb80-d6a9-11e8-8647-1bceed9f7f92.png)
![simulator screen shot - iphone xr - 2018-10-23 at 09 43 10](https://user-images.githubusercontent.com/8409475/47365478-a58b7f80-d6a9-11e8-9ab9-cab19573f824.png)
