### PR TITLE
Added observer for when favorite is re-added in same selection view

### DIFF
--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/SelectionViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/SelectionViewController.swift
@@ -109,6 +109,7 @@ class SelectionViewController: UIViewController {
     
     func addCurrentSelectionToFavorites(for favorite: FavoriteSelection) {
         FavoritesManager.shared.addFavorite(favorite: favorite)
+        NotificationCenter.default.post(name: NSNotification.Name("load"), object: nil)
     }
     
     func manageFavorites() {


### PR DESCRIPTION
## What you did :question:
- Fixed issue in which a favorite that was re-added from the same Selection View wasn't repopulated in the favorites collection view

## How you did it :white_check_mark:
- Added NotificationCenter post in addCurrentSelectionToFavorites in SelectionViewController:
`NotificationCenter.default.post(name: NSNotification.Name("load"), object: nil)`


## How to test it :microscope:
- Run the app
- Tap 'Play!'
- Choose any selection
- Tap 'See Selection'
- Tap the favorite icon (heart) once to add the visible selection the Favorites (heart should be filled)
- Tap 'X' to dismiss Selection View
- Tap 'Back' to return to the Home View
- Tap 'Faves' to navigate to Favorites
- Tap the black card label that represents the saved favorite
- Tap the favorite icon (heart) to delete the visible selection from Favorites (heart should be empty)
- Tap the favorite icon (heart) again to re-add the selection to Favorites (heart should be filled)


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-10-23 at 17 34 23](https://user-images.githubusercontent.com/8409475/47392572-fe2f3c80-d6ea-11e8-98dd-d59e5204b507.png)
![simulator screen shot - iphone xr - 2018-10-23 at 17 34 26](https://user-images.githubusercontent.com/8409475/47392582-04bdb400-d6eb-11e8-9149-62cd37ec83ee.png)
![simulator screen shot - iphone xr - 2018-10-23 at 17 34 29](https://user-images.githubusercontent.com/8409475/47392598-14d59380-d6eb-11e8-8205-47b7601feab2.png)
![simulator screen shot - iphone xr - 2018-10-23 at 17 34 31](https://user-images.githubusercontent.com/8409475/47392613-1c953800-d6eb-11e8-8cc7-b5945537b777.png)
