### PR TITLE
Play: dynamic buttons

### DIFF
--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Controllers/PlayViewController.swift
@@ -87,8 +87,13 @@ class PlayViewController: UIViewController {
         whiteCard3 = HTMLDecode.decodeHTMLString(for: encodedStringThree).string
         
         whiteCardPhrase1Button.setTitle(whiteCard1, for: .normal)
+        //whiteCardPhrase1Button.sizeToFit()
+        
         whiteCardPhrase2Button.setTitle(whiteCard2, for: .normal)
+        //whiteCardPhrase2Button.sizeToFit()
+        
         whiteCardPhrase3Button.setTitle(whiteCard3, for: .normal)
+        //whiteCardPhrase3Button.sizeToFit()
     }
     
     func isBlackCardTextEmpty(in blackCard: BlackCard) -> Bool {

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
@@ -133,19 +133,19 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j4j-TX-dzL" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                <rect key="frame" x="105" y="358" width="165" height="36"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j4j-TX-dzL" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
+                                <rect key="frame" x="80" y="318.5" width="215" height="30"/>
                                 <color key="backgroundColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <state key="normal" title="whiteCard phrase 1"/>
+                                <state key="normal" title="whiteCard phrase 1">
+                                    <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
                                 <connections>
                                     <action selector="userTappedPhraseButton:" destination="Ijd-Er-kX9" eventType="touchUpInside" id="6fG-wz-3Rv"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RXZ-dk-agm" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                <rect key="frame" x="105" y="536" width="165" height="36"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RXZ-dk-agm" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
+                                <rect key="frame" x="80" y="418.5" width="215" height="30"/>
                                 <color key="backgroundColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="whiteCard phrase 3"/>
@@ -153,9 +153,8 @@
                                     <action selector="userTappedPhraseButton:" destination="Ijd-Er-kX9" eventType="touchUpInside" id="qcV-yf-dzq"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0lE-Lo-PT1" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                <rect key="frame" x="105" y="446" width="165" height="36"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0lE-Lo-PT1" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
+                                <rect key="frame" x="80" y="368.5" width="215" height="30"/>
                                 <color key="backgroundColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="whiteCard phrase 2"/>
@@ -202,6 +201,18 @@
                             </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="JDT-Kn-ml7" firstAttribute="trailing" secondItem="0lE-Lo-PT1" secondAttribute="trailing" constant="80" id="QOU-zY-4jX"/>
+                            <constraint firstItem="0lE-Lo-PT1" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="80" id="YVs-b8-eg7"/>
+                            <constraint firstItem="RXZ-dk-agm" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="80" id="Zsq-TX-oiM"/>
+                            <constraint firstItem="0lE-Lo-PT1" firstAttribute="top" secondItem="j4j-TX-dzL" secondAttribute="bottom" constant="20" id="ccj-AI-cqX"/>
+                            <constraint firstItem="j4j-TX-dzL" firstAttribute="centerY" secondItem="Hjq-i9-cpf" secondAttribute="centerY" id="dZc-5B-Ity"/>
+                            <constraint firstItem="RXZ-dk-agm" firstAttribute="top" secondItem="0lE-Lo-PT1" secondAttribute="bottom" constant="20" id="e3Z-vk-zaO"/>
+                            <constraint firstItem="JDT-Kn-ml7" firstAttribute="trailing" secondItem="RXZ-dk-agm" secondAttribute="trailing" constant="80" id="j5X-SQ-gWZ"/>
+                            <constraint firstItem="j4j-TX-dzL" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="80" id="kKa-1l-DY9"/>
+                            <constraint firstItem="j4j-TX-dzL" firstAttribute="centerX" secondItem="Hjq-i9-cpf" secondAttribute="centerX" id="oV0-eJ-Stf"/>
+                            <constraint firstItem="JDT-Kn-ml7" firstAttribute="trailing" secondItem="j4j-TX-dzL" secondAttribute="trailing" constant="80" id="uS7-oy-pSw"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="JDT-Kn-ml7"/>
                     </view>
                     <navigationItem key="navigationItem" id="TGn-du-VPK"/>
@@ -318,6 +329,6 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="Uax-ch-NMh"/>
+        <segue reference="AfY-04-MiS"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
@@ -133,9 +133,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j4j-TX-dzL" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                <rect key="frame" x="80" y="318.5" width="215" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="j4j-TX-dzL" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
+                                <rect key="frame" x="80" y="308.5" width="215" height="50"/>
                                 <color key="backgroundColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="mEl-VX-jxw"/>
+                                </constraints>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="whiteCard phrase 1">
                                     <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -144,18 +147,24 @@
                                     <action selector="userTappedPhraseButton:" destination="Ijd-Er-kX9" eventType="touchUpInside" id="6fG-wz-3Rv"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RXZ-dk-agm" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                <rect key="frame" x="80" y="418.5" width="215" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="RXZ-dk-agm" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
+                                <rect key="frame" x="80" y="448.5" width="215" height="50"/>
                                 <color key="backgroundColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="GL3-eu-6gw"/>
+                                </constraints>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="whiteCard phrase 3"/>
                                 <connections>
                                     <action selector="userTappedPhraseButton:" destination="Ijd-Er-kX9" eventType="touchUpInside" id="qcV-yf-dzq"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0lE-Lo-PT1" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                <rect key="frame" x="80" y="368.5" width="215" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="0lE-Lo-PT1" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
+                                <rect key="frame" x="80" y="378.5" width="215" height="50"/>
                                 <color key="backgroundColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="MPt-36-mlC"/>
+                                </constraints>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="whiteCard phrase 2"/>
                                 <connections>

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
@@ -188,8 +188,8 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IEF-oe-ZLX">
-                                <rect key="frame" x="242" y="617" width="117" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IEF-oe-ZLX">
+                                <rect key="frame" x="188.5" y="618.5" width="117" height="30"/>
                                 <color key="backgroundColor" red="1" green="0.050894779430000002" blue="0.47870025989999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="117" id="UdA-M9-BzL"/>
@@ -202,8 +202,8 @@
                                     <segue destination="syK-vQ-tIn" kind="presentation" identifier="playToSelection" id="AfY-04-MiS"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RTp-in-HkP">
-                                <rect key="frame" x="16" y="617" width="117" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RTp-in-HkP">
+                                <rect key="frame" x="-11.5" y="618.5" width="117" height="30"/>
                                 <color key="backgroundColor" red="1" green="0.050894779430000002" blue="0.47870025989999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="lGP-Iq-gCg"/>
@@ -219,16 +219,20 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstItem="IEF-oe-ZLX" firstAttribute="centerY" secondItem="RTp-in-HkP" secondAttribute="centerY" id="7eL-Bw-jgS"/>
+                            <constraint firstItem="RTp-in-HkP" firstAttribute="centerX" secondItem="Hjq-i9-cpf" secondAttribute="centerX" constant="-100" id="FO2-Bl-XSp"/>
                             <constraint firstItem="S2a-Oq-elc" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="63" id="IGr-83-VM8"/>
                             <constraint firstItem="JDT-Kn-ml7" firstAttribute="trailing" secondItem="0lE-Lo-PT1" secondAttribute="trailing" constant="80" id="QOU-zY-4jX"/>
                             <constraint firstItem="0lE-Lo-PT1" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="80" id="YVs-b8-eg7"/>
                             <constraint firstItem="RXZ-dk-agm" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="80" id="Zsq-TX-oiM"/>
                             <constraint firstItem="qMv-TW-pbJ" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="64" id="Zy5-YG-DWG"/>
+                            <constraint firstItem="IEF-oe-ZLX" firstAttribute="centerX" secondItem="Hjq-i9-cpf" secondAttribute="centerX" constant="100" id="cQj-OO-Ohq"/>
                             <constraint firstItem="0lE-Lo-PT1" firstAttribute="top" secondItem="j4j-TX-dzL" secondAttribute="bottom" constant="20" id="ccj-AI-cqX"/>
                             <constraint firstItem="j4j-TX-dzL" firstAttribute="centerY" secondItem="Hjq-i9-cpf" secondAttribute="centerY" id="dZc-5B-Ity"/>
                             <constraint firstItem="RXZ-dk-agm" firstAttribute="top" secondItem="0lE-Lo-PT1" secondAttribute="bottom" constant="20" id="e3Z-vk-zaO"/>
                             <constraint firstItem="JDT-Kn-ml7" firstAttribute="trailing" secondItem="RXZ-dk-agm" secondAttribute="trailing" constant="80" id="j5X-SQ-gWZ"/>
                             <constraint firstItem="j4j-TX-dzL" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="80" id="kKa-1l-DY9"/>
+                            <constraint firstItem="RTp-in-HkP" firstAttribute="centerY" secondItem="Hjq-i9-cpf" secondAttribute="centerY" constant="300" id="nRu-EW-4T9"/>
                             <constraint firstItem="JDT-Kn-ml7" firstAttribute="trailing" secondItem="qMv-TW-pbJ" secondAttribute="trailing" constant="64" id="o43-Gz-pmS"/>
                             <constraint firstItem="j4j-TX-dzL" firstAttribute="centerX" secondItem="Hjq-i9-cpf" secondAttribute="centerX" id="oV0-eJ-Stf"/>
                             <constraint firstItem="qMv-TW-pbJ" firstAttribute="top" secondItem="S2a-Oq-elc" secondAttribute="bottom" constant="20" id="qWi-Lo-o60"/>

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
@@ -171,34 +171,6 @@
                                     <action selector="userTappedPhraseButton:" destination="Ijd-Er-kX9" eventType="touchUpInside" id="UDx-cC-SM9"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="pickNumberLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qMv-TW-pbJ">
-                                <rect key="frame" x="64" y="333" width="166" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IEF-oe-ZLX">
-                                <rect key="frame" x="242" y="617" width="117" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" red="1" green="0.050894779430000002" blue="0.47870025989999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <state key="normal" title="See Selection ">
-                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <segue destination="syK-vQ-tIn" kind="presentation" identifier="playToSelection" id="AfY-04-MiS"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RTp-in-HkP">
-                                <rect key="frame" x="16" y="617" width="117" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" red="1" green="0.050894779430000002" blue="0.47870025989999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <state key="normal" title="New Round">
-                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="userTappedNewRoundButton:" destination="Ijd-Er-kX9" eventType="touchUpInside" id="tcS-bg-BVh"/>
-                                </connections>
-                            </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="blackCard phrase" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S2a-Oq-elc">
                                 <rect key="frame" x="63" y="113" width="168" height="200"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -210,6 +182,40 @@
                                 <color key="textColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="pickNumberLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qMv-TW-pbJ">
+                                <rect key="frame" x="64" y="333" width="166" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IEF-oe-ZLX">
+                                <rect key="frame" x="242" y="617" width="117" height="30"/>
+                                <color key="backgroundColor" red="1" green="0.050894779430000002" blue="0.47870025989999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="117" id="UdA-M9-BzL"/>
+                                    <constraint firstAttribute="height" constant="30" id="sDb-dZ-G2i"/>
+                                </constraints>
+                                <state key="normal" title="See Selection ">
+                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <segue destination="syK-vQ-tIn" kind="presentation" identifier="playToSelection" id="AfY-04-MiS"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RTp-in-HkP">
+                                <rect key="frame" x="16" y="617" width="117" height="30"/>
+                                <color key="backgroundColor" red="1" green="0.050894779430000002" blue="0.47870025989999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="lGP-Iq-gCg"/>
+                                    <constraint firstAttribute="width" constant="117" id="vXR-Vq-Dts"/>
+                                </constraints>
+                                <state key="normal" title="New Round">
+                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="userTappedNewRoundButton:" destination="Ijd-Er-kX9" eventType="touchUpInside" id="tcS-bg-BVh"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>

--- a/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
+++ b/SFWCardsAgainstHumanity/SFWCardsAgainstHumanity/Views/Base.lproj/Main.storyboard
@@ -134,7 +134,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="j4j-TX-dzL" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                <rect key="frame" x="80" y="308.5" width="215" height="50"/>
+                                <rect key="frame" x="80" y="308.5" width="134" height="50"/>
                                 <color key="backgroundColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="mEl-VX-jxw"/>
@@ -148,7 +148,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="RXZ-dk-agm" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                <rect key="frame" x="80" y="448.5" width="215" height="50"/>
+                                <rect key="frame" x="80" y="448.5" width="134" height="50"/>
                                 <color key="backgroundColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="GL3-eu-6gw"/>
@@ -160,7 +160,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageWhenHighlighted="NO" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="0lE-Lo-PT1" customClass="BorderedButton" customModule="SFWCardsAgainstHumanity" customModuleProvider="target">
-                                <rect key="frame" x="80" y="378.5" width="215" height="50"/>
+                                <rect key="frame" x="80" y="378.5" width="134" height="50"/>
                                 <color key="backgroundColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="MPt-36-mlC"/>
@@ -171,17 +171,8 @@
                                     <action selector="userTappedPhraseButton:" destination="Ijd-Er-kX9" eventType="touchUpInside" id="UDx-cC-SM9"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="blackCard phrase" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S2a-Oq-elc">
-                                <rect key="frame" x="63" y="113" width="248" height="131"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="pickNumberLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qMv-TW-pbJ">
-                                <rect key="frame" x="79" y="300" width="216" height="29"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="pickNumberLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qMv-TW-pbJ">
+                                <rect key="frame" x="64" y="333" width="166" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -208,19 +199,36 @@
                                     <action selector="userTappedNewRoundButton:" destination="Ijd-Er-kX9" eventType="touchUpInside" id="tcS-bg-BVh"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="blackCard phrase" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S2a-Oq-elc">
+                                <rect key="frame" x="63" y="113" width="168" height="200"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="200" id="36t-WM-NsJ"/>
+                                    <constraint firstAttribute="width" constant="250" id="It4-sT-2D8"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstItem="S2a-Oq-elc" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="63" id="IGr-83-VM8"/>
                             <constraint firstItem="JDT-Kn-ml7" firstAttribute="trailing" secondItem="0lE-Lo-PT1" secondAttribute="trailing" constant="80" id="QOU-zY-4jX"/>
                             <constraint firstItem="0lE-Lo-PT1" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="80" id="YVs-b8-eg7"/>
                             <constraint firstItem="RXZ-dk-agm" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="80" id="Zsq-TX-oiM"/>
+                            <constraint firstItem="qMv-TW-pbJ" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="64" id="Zy5-YG-DWG"/>
                             <constraint firstItem="0lE-Lo-PT1" firstAttribute="top" secondItem="j4j-TX-dzL" secondAttribute="bottom" constant="20" id="ccj-AI-cqX"/>
                             <constraint firstItem="j4j-TX-dzL" firstAttribute="centerY" secondItem="Hjq-i9-cpf" secondAttribute="centerY" id="dZc-5B-Ity"/>
                             <constraint firstItem="RXZ-dk-agm" firstAttribute="top" secondItem="0lE-Lo-PT1" secondAttribute="bottom" constant="20" id="e3Z-vk-zaO"/>
                             <constraint firstItem="JDT-Kn-ml7" firstAttribute="trailing" secondItem="RXZ-dk-agm" secondAttribute="trailing" constant="80" id="j5X-SQ-gWZ"/>
                             <constraint firstItem="j4j-TX-dzL" firstAttribute="leading" secondItem="JDT-Kn-ml7" secondAttribute="leading" constant="80" id="kKa-1l-DY9"/>
+                            <constraint firstItem="JDT-Kn-ml7" firstAttribute="trailing" secondItem="qMv-TW-pbJ" secondAttribute="trailing" constant="64" id="o43-Gz-pmS"/>
                             <constraint firstItem="j4j-TX-dzL" firstAttribute="centerX" secondItem="Hjq-i9-cpf" secondAttribute="centerX" id="oV0-eJ-Stf"/>
+                            <constraint firstItem="qMv-TW-pbJ" firstAttribute="top" secondItem="S2a-Oq-elc" secondAttribute="bottom" constant="20" id="qWi-Lo-o60"/>
+                            <constraint firstItem="S2a-Oq-elc" firstAttribute="top" secondItem="JDT-Kn-ml7" secondAttribute="top" constant="49" id="sOc-5e-cVY"/>
                             <constraint firstItem="JDT-Kn-ml7" firstAttribute="trailing" secondItem="j4j-TX-dzL" secondAttribute="trailing" constant="80" id="uS7-oy-pSw"/>
+                            <constraint firstItem="JDT-Kn-ml7" firstAttribute="trailing" secondItem="S2a-Oq-elc" secondAttribute="trailing" constant="63" id="vbx-eF-Jht"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="JDT-Kn-ml7"/>
                     </view>


### PR DESCRIPTION
## What you did :question:
- Used Auto Layout and button attribute settings to word wrap the text in the white card phrase buttons
- Used Auto Layout to align all the elements on the Play View Controller

## How you did it :white_check_mark:
- Increased button size (constraints >= button height), set button text to 'Word Wrap'
- Constrained blackCardLabel width and height
- Constrained 'New Round' and 'See Selection' buttons with alignment constraints

#### Sources:
- George!

## How to test it :microscope:
- Run the app
- Tap 'Play!'
- Note that the elements in the Play View are aligned (see screenshot)


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-10-24 at 14 39 36](https://user-images.githubusercontent.com/8409475/47453418-a8b26880-d79a-11e8-8f1f-ea6f5b5efd9f.png)

